### PR TITLE
update schedule

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -6,14 +6,14 @@ title: MinneHONK! 2025
 layout: default
 ---
 
-![MinneHONK Banner](minnehonk.png)
+# ![MinneHONK Banner](minnehonk.png)
 
 MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on Saturday May 3 and Sunday, May 4, 2025.
 
-* On May 3rd, MinneHONK! will bring music to [George Floyd Square](https://www.openstreetmap.org/?#map=19/44.934158/-93.262500) from 12pm to 5pm. (Times are approximates and subject to change.)
-* On May 4th, MinneHONK! bands will participate in musical performances coinciding with the [MayDay Parade and Ceremony](https://www.maydaympls.org) proceedings at Powderhorn Park.
+* On May 3rd, MinneHONK! will bring music to [George Floyd Square](https://www.openstreetmap.org/?#map=19/44.934158/-93.262500) from 12pm to 5pm.
+* On May 4th, MinneHONK! bands will participate in musical performances coinciding with the [Mayday Parade and Ceremony](https://www.maydaympls.org) proceedings at Powderhorn Park.
 
-# Schedule
+## Saturday, May 3
 
 **Say Their Names Cemetery (37th & Columbus)**
 * 12:00 - 1:00: _Opening Ceremony_
@@ -27,4 +27,23 @@ MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on S
 **People's Way (38th & Chicago)**
 * 1:30 - 2:15: [Unlawful Assembly](http://unlawfulassembly.org)
 * 2:15 - 3:00: [Brass Messengers](http://www.brassmessengers.com/about)
+* 3:00 - 4:00: _TBD_ <small>(interested artists, email [info@minnehonk.org](mailto:info@minnehonk.org))</small>
 * 4:00 - 5:30: _Open Jam Session_
+
+## Sunday, May 4
+
+There's a lot of cool stuff going on at around Powderhorn Park for Mayday, this is just a short list of where to find MinneHONK! bands that are also participating in Mayday.
+
+**Mayday Parade**
+* 11:00: parade line-up at [Bloomington Avenue & East 28th Street](geo:44.951941,-93.252489)
+* 12:00: parade start
+
+Route map and other parade information are available at [maydaympls.org/parade](https://maydaympls.org/parade).
+
+**Mayday Ceremony**
+
+Follows the parade, on west side of Powderhorn Lake; more information at [maydaympls.org/ceremony](https://www.maydaympls.org/ceremony).
+
+**Reverie Block Party**
+
+"In the Spirit of MayDay Block Party" [outside Reverie](geo:44.939557,-93.252785) has a musical lineup from 2pm-9pm, including MinneHONK! bands Brass Solidarity at 4pm and Brass Messengers at 8pm. More information at [reveriempls.com/mayday](https://www.reveriempls.com/mayday).

--- a/index.markdown
+++ b/index.markdown
@@ -18,8 +18,8 @@ MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on S
 **Say Their Names Cemetery (37th St & Columbus Ave)**
 * 12:00 - 1:00: _Opening Ceremony_
 
-* 1:00 - 1:45: [Kalpulli KetzalCoatlicue (Aztec Dancers)](https://www.danzaketzal.com/history)
 **Northern Fist (37th St & Chicago Ave)**
+* 1:00 - 1:45: [Kalpulli KetzalCoatlicue](https://www.danzaketzal.com/history)
 * 1:45 - 2:30: [Forward! Marching Band](https://fmbwebsite.wixsite.com/forwardmb)
 * 2:30 - 3:15: [AFOUTAYI](https://www.afoutayidmaco.com)
 * 3:15 - 4:00: [Brass Solidarity](https://brasssolidarity.com/about/)
@@ -32,7 +32,7 @@ MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on S
 
 ## Sunday, May 4
 
-There's a lot of cool stuff going on at around Powderhorn Park for Mayday, this is just a short list of where to find MinneHONK! bands that are also participating in Mayday.
+There's a lot of cool stuff going on at Powderhorn Park for Mayday; this is just a short list of where to find MinneHONK! bands that are also participating in Mayday.
 
 **Mayday Parade**
 * 11:00am: parade line-up at Bloomington Ave & E 28th St

--- a/index.markdown
+++ b/index.markdown
@@ -6,7 +6,7 @@ title: MinneHONK! 2025
 layout: default
 ---
 
-# ![MinneHONK Banner](minnehonk.png)
+# ![MinneHONK Banner](minnehonk.png)<span style="display:none">MinneHONK</span>
 
 MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on Saturday May 3 and Sunday, May 4, 2025.
 

--- a/index.markdown
+++ b/index.markdown
@@ -15,16 +15,16 @@ MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on S
 
 ## Saturday, May 3
 
-**Say Their Names Cemetery (37th & Columbus)**
+**Say Their Names Cemetery (37th St & Columbus Ave)**
 * 12:00 - 1:00: _Opening Ceremony_
 
-**Northern Fist (37th & Chicago)**
 * 1:00 - 1:45: [Kalpulli KetzalCoatlicue (Aztec Dancers)](https://www.danzaketzal.com/history)
+**Northern Fist (37th St & Chicago Ave)**
 * 1:45 - 2:30: [Forward! Marching Band](https://fmbwebsite.wixsite.com/forwardmb)
 * 2:30 - 3:15: [AFOUTAYI](https://www.afoutayidmaco.com)
 * 3:15 - 4:00: [Brass Solidarity](https://brasssolidarity.com/about/)
 
-**People's Way (38th & Chicago)**
+**People's Way (38th St & Chicago Ave)**
 * 1:30 - 2:15: [Unlawful Assembly](http://unlawfulassembly.org)
 * 2:15 - 3:00: [Brass Messengers](http://www.brassmessengers.com/about)
 * 3:00 - 4:00: _TBD_ <small>(interested artists, email [info@minnehonk.org](mailto:info@minnehonk.org))</small>
@@ -35,8 +35,8 @@ MinneHONK! is a festival of activist street bands in Minneapolis, Minnesota on S
 There's a lot of cool stuff going on at around Powderhorn Park for Mayday, this is just a short list of where to find MinneHONK! bands that are also participating in Mayday.
 
 **Mayday Parade**
-* 11:00: parade line-up at [Bloomington Avenue & East 28th Street](geo:44.951941,-93.252489)
-* 12:00: parade start
+* 11:00am: parade line-up at Bloomington Ave & E 28th St
+* 12:00pm: parade start
 
 Route map and other parade information are available at [maydaympls.org/parade](https://maydaympls.org/parade).
 
@@ -46,4 +46,4 @@ Follows the parade, on west side of Powderhorn Lake; more information at [mayday
 
 **Reverie Block Party**
 
-"In the Spirit of MayDay Block Party" [outside Reverie](geo:44.939557,-93.252785) has a musical lineup from 2pm-9pm, including MinneHONK! bands Brass Solidarity at 4pm and Brass Messengers at 8pm. More information at [reveriempls.com/mayday](https://www.reveriempls.com/mayday).
+"In the Spirit of MayDay Block Party" outside Reverie Cafe + Bar (1517 E 35th St) has a musical lineup from 2pm-9pm, including MinneHONK! bands Brass Solidarity at 4pm and Brass Messengers at 8pm. More information at [reveriempls.com/mayday](https://www.reveriempls.com/mayday).


### PR DESCRIPTION
* make explicit header for Saturday, May 3
* add schedule highlights of Mayday stuff featuring MinneHONK! bands
* change MayDay to Mayday to match style on maydaympls.org (I think this changed?)
* remove "times are approximate line" caveat from top section